### PR TITLE
Snakefile reference database taxonomy file did not match wiki

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -413,7 +413,7 @@ rule import_ref_seqs:
 
 rule import_ref_tax:
     input:
-        "00-data/refseqs.tsv"
+        "00-data/reftax.tsv"
     output:
         "01-imported/reftax.qza"
     threads: config["other_threads"]


### PR DESCRIPTION
Changed refseqs.tsv to reftax.tsv in Snakefile. Only relevant if you are providing your own taxonomy in TSV format.