### PR TITLE
Fix: Handle None values in has_fa_suffix() for pretrained classifiers

### DIFF
--- a/taxonomy_step.Snakefile
+++ b/taxonomy_step.Snakefile
@@ -13,6 +13,8 @@ shutil.copy(workflow.configfiles[0], config_output_path)
 
 # Function to check if the file has a valid suffix
 def has_fa_suffix(file, suffixes):
+    if file is None or file == "":
+        return False
     return any(file.endswith(suffix) for suffix in suffixes)
 
 # Function to change the suffix of a file


### PR DESCRIPTION
## Description
Fixes an `AttributeError` that occurs when using a pretrained classifier with the `naive-bayes` classification method. The `has_fa_suffix()` function was being called on `None` values for `refseqs_file` and `taxa_file`, which are correctly set to `null` when using a pretrained classifier.

## Changes
- Modified `has_fa_suffix()` function to check for `None` and empty string values before calling `.endswith()`
- Returns `False` for `None` or empty values, allowing the `if/elif` chain to proceed correctly

## Error Fixed